### PR TITLE
fix(connection): fix key parsing when key was containing `:` group was incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug Fixes
 
-- **connection:** fix key parsing when key was containing `:` group was incorrect
+- **connection:** fix key parsing when key was containing `:` group was incorrect (only used for logs)
 
 ## [1.0.0-rc3](https://github.com/sketch7/SignalR.Orleans/compare/1.0.0-rc2...1.0.0-rc3) (2019-12-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [_vNext_](https://github.com/sketch7/SignalR.Orleans/compare/1.0.0...1.1.0) (2019-X-X)
 
+## [1.0.0-rc4](https://github.com/sketch7/SignalR.Orleans/compare/1.0.0-rc3...1.0.0-rc4) (2019-12-04)
+
+### Bug Fixes
+
+- **connection:** fix key parsing when key was containing `:` group was incorrect
+
 ## [1.0.0-rc3](https://github.com/sketch7/SignalR.Orleans/compare/1.0.0-rc2...1.0.0-rc3) (2019-12-03)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sketch7/signalr-orleans",
   "version": "1.0.0",
-  "versionSuffix": "rc3",
+  "versionSuffix": "rc4",
   "scripts": {
     "pack": "bash ./tools/pack.sh",
     "prepublish:dev": "npm run pack",

--- a/src/SignalR.Orleans/Constants.cs
+++ b/src/SignalR.Orleans/Constants.cs
@@ -17,7 +17,7 @@ namespace SignalR.Orleans
         public static readonly Guid ALL_STREAM_ID = Guid.Parse("fbe53ecd-d896-4916-8281-5571d6733566");
 
         internal const int STREAM_SEND_REPLICAS = 10; // todo: make configurable instead
-        internal const int HEARTBEAT_PULSE_IN_MINUTES = 30;
-        internal const int SERVERDIRECTORY_CLEANUP_IN_MINUTES = HEARTBEAT_PULSE_IN_MINUTES * 3;
+        internal const double HEARTBEAT_PULSE_IN_MINUTES = 30;
+        internal const double SERVERDIRECTORY_CLEANUP_IN_MINUTES = HEARTBEAT_PULSE_IN_MINUTES * 3;
     }
 }

--- a/src/SignalR.Orleans/Core/ConnectionGrainKey.cs
+++ b/src/SignalR.Orleans/Core/ConnectionGrainKey.cs
@@ -17,10 +17,9 @@ namespace SignalR.Orleans.Core
 
         public void Parse(string primaryKey)
         {
-            var pkArray = primaryKey.Split(':');
-
-            HubName = pkArray[0];
-            Id = pkArray[1];
+            var separatorIndex = primaryKey.IndexOf(':');
+            HubName = primaryKey.Substring(0, separatorIndex);
+            Id = primaryKey.Substring(separatorIndex + 1);
         }
 
         public static string Build(string hubName, string key)


### PR DESCRIPTION
When key (group) was `hero:singed` HubName was correct, however Id ends up just `hero`