### PR TITLE
.NET & Orleans 8 Support

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -21,7 +21,7 @@ jobs:
     name: Package
     uses: sketch7/.github/.github/workflows/dotnet-package.yml@master
     with:
-      dotnet-version: 7.0.x
+      dotnet-version: 8.0.x
       publishable: ${{ contains(fromJSON('["develop", "master", "workflow", "feature/reusable-workflow"]'), github.ref_name) || endsWith(github.ref_name, '.x')  }}
     secrets:
       nuget-auth-token: ${{ secrets.NUGET_KEY }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Shared Package Versions -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- <Nullable>enable</Nullable> -->
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
@@ -40,8 +39,14 @@
 
   <!-- Shared Package Versions -->
   <PropertyGroup>
-    <!-- vendors -->
-    <OrleansVersion>7.2.3</OrleansVersion>
-    <OrleansStreamsUtilsVersion>13.1.3</OrleansStreamsUtilsVersion>
+    <OrleansVersion>7.2.4</OrleansVersion>
   </PropertyGroup>
+
+  <!--<PropertyGroup Condition="'$(TargetFramework)'=='net7.0'">
+    <OrleansVersion>7.2.4</OrleansVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <OrleansVersion>8.0.0</OrleansVersion>
+  </PropertyGroup>-->
 </Project>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sketch7/signalr-orleans",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "versionSuffix": "",
   "scripts": {
     "pack": "bash ./tools/pack.sh",

--- a/src/SignalR.Orleans.AspNet/SignalR.Orleans.AspNet.csproj
+++ b/src/SignalR.Orleans.AspNet/SignalR.Orleans.AspNet.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <PackageId>Sketch7.SignalR.Orleans.AspNet</PackageId>
-    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SignalR.Orleans/KeyedServiceExtensions.cs
+++ b/src/SignalR.Orleans/KeyedServiceExtensions.cs
@@ -1,0 +1,115 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Sketch7;
+
+/// <summary>
+/// Extension method for <see cref="IServiceProvider"/> Orleans 7 compatibility for .NET 8.0.
+/// </summary>
+internal static class KeyedServiceExtensions
+{
+	private static Type _keyedCollectionType;
+	private static Type _keyedServiceType;
+
+	/// <summary>
+	/// Acquire a service by key.
+	/// </summary>
+	/// <typeparam name="TKey">
+	/// The service key type.
+	/// </typeparam>
+	/// <typeparam name="TService">
+	/// The service type.
+	/// </typeparam>
+	/// <param name="services">
+	/// The service provider.
+	/// </param>
+	/// <param name="key">
+	/// The service key.
+	/// </param>
+	/// <returns>The service.</returns>
+	public static TService GetServiceByKey<TKey, TService>(this IServiceProvider services, TKey key)
+		where TService : class
+	{
+		var service = services.GetKeyedService<TService>(key);
+		if (service is not null)
+			return service;
+
+		// Looks like we don't have the service in the .NET 8 collection (Orleans 8 maybe not in use...), so we'll try to get it from the Orleans 7 collection.
+		_keyedServiceType ??= Type.GetType("Orleans.Runtime.IKeyedService`2, Orleans.Core.Abstractions");
+		_keyedCollectionType ??= Type.GetType("Orleans.Runtime.IKeyedServiceCollection`2, Orleans.Core.Abstractions");
+
+		if (_keyedCollectionType is null && _keyedServiceType is null)
+			return null;
+
+		var keyedServiceType = _keyedServiceType?.MakeGenericType(typeof(TKey), typeof(TService));
+		if (keyedServiceType is not null)
+		{
+			var keyedService = (dynamic)services.GetService(keyedServiceType);
+			var keyService = keyedService is not null
+				? (TService)keyedService.GetService(services)
+				: null;
+
+			if (keyService is not null && keyedService.Key.Equals(key))
+				return keyService;
+		}
+
+		var keyedCollectionType = _keyedCollectionType?.MakeGenericType(typeof(TKey), typeof(TService));
+		if (keyedCollectionType is null)
+			return null;
+
+		var keyedCollection = (dynamic)services.GetService(keyedCollectionType);
+		return keyedCollection is not null
+			? (TService)keyedCollection.GetService(services, key)
+			: null;
+	}
+
+	/// <summary>
+	/// Acquire a service by key, throwing if the service is not found.
+	/// </summary>
+	/// <typeparam name="TKey">
+	/// The service key type.
+	/// </typeparam>
+	/// <typeparam name="TService">
+	/// The service type.
+	/// </typeparam>
+	/// <param name="services">
+	/// The service provider.
+	/// </param>
+	/// <param name="key">
+	/// The service key.
+	/// </param>
+	/// <returns>The service.</returns>
+	public static TService GetRequiredServiceByKey<TKey, TService>(this IServiceProvider services, TKey key)
+		where TService : class => services.GetServiceByKey<TKey, TService>(key) ?? throw new KeyNotFoundException(key?.ToString());
+
+	/// <summary>
+	/// Acquire a service by name.
+	/// </summary>
+	/// <typeparam name="TService">
+	/// The service type.
+	/// </typeparam>
+	/// <param name="services">
+	/// The service provider.
+	/// </param>
+	/// <param name="name">
+	/// The service name.
+	/// </param>
+	/// <returns>The service.</returns>
+	public static TService GetServiceByName<TService>(this IServiceProvider services, string name)
+		where TService : class => services.GetServiceByKey<string, TService>(name);
+
+	/// <summary>
+	/// Acquire a service by name, throwing if it is not found.
+	/// </summary>
+	/// <typeparam name="TService">
+	/// The service type.
+	/// </typeparam>
+	/// <param name="services">
+	/// The service provider.
+	/// </param>
+	/// <param name="name">
+	/// The service name.
+	/// </param>
+	/// <returns>The service.</returns>
+	public static TService GetRequiredServiceByName<TService>(this IServiceProvider services, string name)
+		where TService : class => services.GetRequiredServiceByKey<string, TService>(name);
+}

--- a/src/SignalR.Orleans/SignalR.Orleans.csproj
+++ b/src/SignalR.Orleans/SignalR.Orleans.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <PackageId>Sketch7.SignalR.Orleans</PackageId>
-    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SignalR.Orleans/SignalR.Orleans.csproj
+++ b/src/SignalR.Orleans/SignalR.Orleans.csproj
@@ -4,6 +4,11 @@
     <PackageId>Sketch7.SignalR.Orleans</PackageId>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
+    <Compile Remove="KeyedServiceExtensions.cs" />
+    <Content Include="KeyedServiceExtensions.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/test/SignalR.Orleans.Tests/Models/DumbGrainStore.cs
+++ b/test/SignalR.Orleans.Tests/Models/DumbGrainStore.cs
@@ -1,0 +1,13 @@
+﻿using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace SignalR.Orleans.Tests.Models;
+
+internal sealed class DumbGrainStore : IGrainStorage
+{
+	public Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState) => Task.CompletedTask;
+
+	public Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState) => Task.CompletedTask;
+
+	public Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState) => Task.CompletedTask;
+}

--- a/test/SignalR.Orleans.Tests/SignalR.Orleans.Tests.csproj
+++ b/test/SignalR.Orleans.Tests/SignalR.Orleans.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/SignalR.Orleans.Tests/SignalRConfigurationValidatorTests.cs
+++ b/test/SignalR.Orleans.Tests/SignalRConfigurationValidatorTests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using Orleans.Storage;
+using SignalR.Orleans.Tests.Models;
+using System.Net;
+using Xunit;
+
+namespace SignalR.Orleans.Tests;
+
+public sealed class SignalRConfigurationValidatorTests
+{
+	[Fact]
+	public void ValidateConfiguration_Throws_IfNoPubSubProviderIsRegistered()
+	{
+		var siloHost = new HostBuilder()
+			.UseOrleans(builder => builder
+				.UseLocalhostClustering()
+				.Configure<EndpointOptions>(options => options.AdvertisedIPAddress = IPAddress.Loopback)
+				.UseSignalR()
+		)
+		.Build();
+
+		Assert.Throws<InvalidOperationException>(() => siloHost.Start());
+		siloHost.Dispose();
+	}
+
+	[Fact]
+	public void ValidateConfiguration_DoesNotThrow_IfPubSubProviderIsRegistered_With_Orleans7()
+	{
+		var siloHost = new HostBuilder()
+			.UseOrleans(builder => builder
+				.UseLocalhostClustering()
+				.Configure<EndpointOptions>(options => options.AdvertisedIPAddress = IPAddress.Loopback)
+				.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER)
+				.UseSignalR()
+			)
+			.Build();
+
+		siloHost.Start();
+		siloHost.Dispose();
+	}
+
+#if NET8_0_OR_GREATER
+	[Fact]
+	public void ValidateConfiguration_DoesNotThrow_IfPubSubProviderIsRegistered_With_Net8()
+	{
+		var sp = new ServiceCollection()
+			.AddSingleton<ILoggerFactory, LoggerFactory>()
+			.AddKeyedSingleton<IGrainStorage>(
+				serviceKey: Constants.PUBSUB_PROVIDER,
+				implementationFactory: (_, _) => new DumbGrainStore())
+			.BuildServiceProvider();
+
+		var validator = new SignalRConfigurationValidator(sp);
+
+		validator.ValidateConfiguration();
+	}
+#endif
+}


### PR DESCRIPTION
When updating Silo to Orleans 8 the following exception is thrown: `System.TypeLoadException` 

`Could not load type 'Orleans.Runtime.KeyedServiceCollectionExtensions' from assembly 'Orleans.Core.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null'.`

This is because Orleans 8, switched to using .NET 8 keyed dependency injection services and removed their custom keyed services implementation.

This fix attempts to use keyed DI when .NET 8 and Orleans 8 is present otherwise falls back to Orleans 7. 



