### PR TITLE
ci(workflows): align validation and prerelease releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,10 @@ on:
       - "workflow"
     paths-ignore:
       - "**.md"
+      - ".agents/**"
+      - ".claude/**"
+      - ".codex/**"
+      - "skills-lock.json"
 
   workflow_dispatch:
     inputs:
@@ -58,13 +62,11 @@ jobs:
   release:
     name: Release
     needs: publish
-    # Only when a stable (non-prerelease) version was published — i.e. on push to v* branches
-    if: |
-      needs.publish.result == 'success' &&
-      !fromJSON(needs.publish.outputs.isPrerelease)
+    if: needs.publish.result == 'success'
     uses: sketch7/.github/.github/workflows/create-release.yml@release-v1
     with:
       version: ${{ needs.publish.outputs.version }}
+      is-prerelease: ${{ fromJSON(needs.publish.outputs.isPrerelease) }}
 
   bump-main:
     name: Bump main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,13 @@ name: CI
 on:
   push:
     branches:
-      - main
-      - "v*"
       - "workflow"
     paths-ignore:
       - "**.md"
+      - ".agents/**"
+      - ".claude/**"
+      - ".codex/**"
+      - "skills-lock.json"
 
   pull_request:
     branches:
@@ -15,6 +17,10 @@ on:
       - "v*"
     paths-ignore:
       - "**.md"
+      - ".agents/**"
+      - ".claude/**"
+      - ".codex/**"
+      - "skills-lock.json"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- run CI on pull requests to main/v* and workflow-branch pushes, avoiding duplicate validation after merges and release-branch updates
- align CI/CD path ignores for agent and skills configuration
- create GitHub Releases for prerelease publishes and mark them as prereleases

## Validation

- actionlint v1.7.12 .github/workflows/ci.yml .github/workflows/cd.yml
- dotnet restore
- dotnet build --no-restore
- dotnet test --no-build (26 tests passed)
- git diff --check